### PR TITLE
feat: Add performance instrumentation and heavyweight tests

### DIFF
--- a/Board.hpp
+++ b/Board.hpp
@@ -7,6 +7,7 @@
 #include "GameTypes.hpp" // Defines GameSet, SetType
 #include "utilities.hpp" // For sorting tiles if necessary within sets, and other board utilities
 #include "SetFinder.hpp" // For find_all_possible_sets
+#include "PerformanceTracer.hpp" // For performance tracing
 
 // class Tile; // Forward declaration no longer needed if GameTypes pulls it.
 
@@ -66,6 +67,7 @@ public:
 
     // Checks if all sets on the board are valid and all tiles are unique across sets.
     bool isValidBoard() const {
+        TRACE_FUNCTION();
         if (sets.empty()) {
             return true; // An empty board is considered valid.
         }
@@ -102,6 +104,7 @@ public:
 // Function to check if a collection of sets represents a valid board state.
 // This is useful for validating potential new board configurations before committing them.
 inline bool is_board_valid(const std::vector<GameSet>& board_sets) {
+    TRACE_FUNCTION();
     if (board_sets.empty()) {
         return true; // An empty collection of sets is valid.
     }
@@ -124,6 +127,7 @@ bool find_valid_arrangement_recursive(
     std::set<Tile>& used_tiles_from_add_pool, // Tracks which of original_tiles_to_add_set are in current_arrangement
     size_t total_tiles_to_place // The total number of tiles in the initial combined pool
 ) {
+    TRACE_FUNCTION();
     // Base Case 1: All tiles from the initial combined pool have been placed into sets
     if (current_pool_tiles.empty()) {
         // Check if all *specific* tiles from tiles_to_add were used
@@ -202,6 +206,7 @@ inline BoardState can_add_tiles_to_board(
     const BoardState& current_board_state,
     const std::vector<Tile>& tiles_to_add
 ) {
+    TRACE_FUNCTION();
     // Step 1: Combine tiles
     std::vector<Tile> current_board_tiles = current_board_state.getAllTiles();
     std::vector<Tile> combined_pool = current_board_tiles;

--- a/GameTypes.hpp
+++ b/GameTypes.hpp
@@ -8,6 +8,7 @@
 #include "Tile.hpp"
 #include "runs.hpp"   // For isValidRun
 #include "groups.hpp" // For isValidGroup
+#include "PerformanceTracer.hpp" // For performance tracing
 // utilities.hpp might be needed if GameSet used functions from it, currently doesn't seem to.
 // However, isValidRun/isValidGroup from runs.hpp/groups.hpp *do* include utilities.hpp.
 
@@ -26,6 +27,7 @@ public:
     }
 
     bool isValid() const {
+        TRACE_FUNCTION();
         if (tiles.empty()) {
             return false;
         }

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
 CXX=g++
 CXXFLAGS=-march=native -mtune=native -std=c++14 -g -Ofast
 
+# Performance tracing flag
+TRACE ?= 0
+ifeq ($(TRACE), 1)
+	CXXFLAGS += -DENABLE_PERFORMANCE_TRACING
+endif
+
 all:
 	$(CXX) $(CXXFLAGS) main.cpp -o rummikub
 
 test: test.o Tile.o
 	$(CXX) $(CXXFLAGS) test.o Tile.o -o test
 
-test.o: test.cpp Board.hpp Tile.hpp utilities.hpp groups.hpp runs.hpp
+test.o: test.cpp Board.hpp Tile.hpp utilities.hpp groups.hpp runs.hpp PerformanceTracer.hpp GameTypes.hpp SetFinder.hpp
 	$(CXX) $(CXXFLAGS) -c test.cpp -o test.o
 
 Tile.o: Tile.cpp Tile.hpp color.h

--- a/PerformanceTracer.hpp
+++ b/PerformanceTracer.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <map>
+#include <chrono>
+#include <iomanip> // For std::fixed and std::setprecision
+
+// To enable tracing, define ENABLE_PERFORMANCE_TRACING before including this header,
+// or pass it as a compiler flag (e.g., -DENABLE_PERFORMANCE_TRACING)
+
+#ifdef ENABLE_PERFORMANCE_TRACING
+
+namespace PerformanceTracer {
+
+struct FunctionProfile {
+    long long total_nanoseconds;
+    long long call_count;
+    std::chrono::time_point<std::chrono::high_resolution_clock> start_time; // Temporary for nested calls
+
+    FunctionProfile() : total_nanoseconds(0), call_count(0) {}
+};
+
+// Global map to store function profiles
+inline std::map<std::string, FunctionProfile>& get_profiles() {
+    static std::map<std::string, FunctionProfile> profiles;
+    return profiles;
+}
+
+class TimeGuard {
+public:
+    TimeGuard(const std::string& function_name)
+        : name(function_name), start_time(std::chrono::high_resolution_clock::now()) {
+        get_profiles()[name].call_count++;
+    }
+
+    ~TimeGuard() {
+        auto end_time = std::chrono::high_resolution_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time);
+        get_profiles()[name].total_nanoseconds += duration.count();
+    }
+
+private:
+    std::string name;
+    std::chrono::time_point<std::chrono::high_resolution_clock> start_time;
+};
+
+inline void print_performance_report() {
+    std::cout << "\n--- Performance Report ---" << std::endl;
+    std::cout << std::left << std::setw(50) << "Function"
+              << std::right << std::setw(15) << "Call Count"
+              << std::setw(25) << "Total Time (ns)"
+              << std::setw(25) << "Avg Time/Call (ns)" << std::endl;
+    std::cout << std::string(115, '-') << std::endl;
+
+    for (const auto& pair : get_profiles()) {
+        const std::string& name = pair.first;
+        const FunctionProfile& profile = pair.second;
+        long double avg_time_per_call = 0;
+        if (profile.call_count > 0) {
+            avg_time_per_call = static_cast<long double>(profile.total_nanoseconds) / profile.call_count;
+        }
+
+        std::cout << std::left << std::setw(50) << name
+                  << std::right << std::setw(15) << profile.call_count
+                  << std::setw(25) << profile.total_nanoseconds
+                  << std::setw(25) << std::fixed << std::setprecision(2) << avg_time_per_call
+                  << std::endl;
+    }
+    std::cout << "--------------------------" << std::endl;
+}
+
+// Macro to create a TimeGuard object easily
+#define TRACE_FUNCTION() PerformanceTracer::TimeGuard time_guard_obj(__func__) // __func__ gives the current function name
+
+} // namespace PerformanceTracer
+
+#else // ENABLE_PERFORMANCE_TRACING is not defined
+
+// Define macros as no-ops if tracing is disabled
+#define TRACE_FUNCTION()
+namespace PerformanceTracer {
+    inline void print_performance_report() {
+        // Do nothing if tracing is disabled
+        // std::cout << "\nPerformance tracing was disabled at compile time." << std::endl;
+    }
+} // namespace PerformanceTracer
+
+#endif // ENABLE_PERFORMANCE_TRACING

--- a/SetFinder.hpp
+++ b/SetFinder.hpp
@@ -5,6 +5,7 @@
 #include <map>       // For grouping by color in findRuns
 #include <set>       // To avoid duplicate sets if any
 #include "GameTypes.hpp" // For GameSet, SetType, and it pulls in Tile.hpp, runs.hpp, groups.hpp
+#include "PerformanceTracer.hpp" // For performance tracing
 
 // Note: runs.hpp, groups.hpp, Tile.hpp are already included by GameTypes.hpp.
 // Explicitly including them here is redundant but harmless due to include guards.
@@ -168,6 +169,7 @@ std::vector<GameSet> findAllValidGroups(std::vector<Tile> tiles) {
 // However, findRuns/findGroups already take by value, which makes a copy.
 // So, find_all_possible_sets can just pass its const& argument.
 std::vector<GameSet> find_all_possible_sets(const std::vector<Tile>& input_tiles) {
+    TRACE_FUNCTION();
     std::vector<GameSet> all_sets;
 
     // Pass input_tiles (const ref). The by-value parameters in the helper functions


### PR DESCRIPTION
Implemented performance instrumentation for key functions related to board manipulation and set validation, including:
- BoardManipulation::can_add_tiles_to_board
- BoardManipulation::find_valid_arrangement_recursive
- SetFinder::find_all_possible_sets
- GameSet::isValid
- BoardState::isValidBoard
- is_board_valid

Instrumentation can be enabled at compile time by defining the ENABLE_PERFORMANCE_TRACING macro (e.g., via `make TRACE=1`). When enabled, a report is printed at the end of the test execution, showing call counts, total time, and average time per call for instrumented functions.

Added new heavyweight test cases for `can_add_tiles_to_board` to `test.cpp`. These tests involve larger initial board states and various scenarios for adding new tiles, including cases that require complex board reorganization and cases where additions are not possible. Adjusted test expectations to align with the algorithm's behavior of finding any valid board configuration.